### PR TITLE
Added the DockerFile for BitcoinClassic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,6 @@ xt_0.11.0d:
 
 bu_0.11.2:
   build: docker/bu/0.11.2
+
+cl_0.11.2:
+  build: docker/cl/0.11.2

--- a/docker/cl/0.11.2/Dockerfile
+++ b/docker/cl/0.11.2/Dockerfile
@@ -1,6 +1,6 @@
 FROM qubinode_base
 
 RUN wget https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v0.11.2.cl1/bitcoin-0.11.2-linux64.tar.gz
-RUN echo "ba0e8d553271687bc8184a4a703f4eb95a832c205d1fe3b3f4537df667f17f3a6be61416d11597feb666bde4ca70e5d350171036f13c838db49bb0aabe5c5e49  bitcoin-0.11.2-linux64.tar.gz" | sha256sum -c
+RUN echo "3f4eb95a832c205d1fe3b3f4537df667f17f3a6be61416d11597feb666bde4ca  bitcoin-0.11.2-linux64.tar.gz" | sha256sum -c
 RUN tar xf bitcoin-0.11.2-linux64.tar.gz
 RUN cp -pr bitcoin-0.11.2-linux64/* /usr/

--- a/docker/cl/0.11.2/Dockerfile
+++ b/docker/cl/0.11.2/Dockerfile
@@ -1,0 +1,6 @@
+FROM qubinode_base
+
+RUN wget https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v0.11.2.cl1/bitcoin-0.11.2-linux64.tar.gz
+RUN echo "ba0e8d553271687bc8184a4a703f4eb95a832c205d1fe3b3f4537df667f17f3a6be61416d11597feb666bde4ca70e5d350171036f13c838db49bb0aabe5c5e49  bitcoin-0.11.2-linux64.tar.gz" | sha256sum -c
+RUN tar xf bitcoin-0.11.2-linux64.tar.gz
+RUN cp -pr bitcoin-0.11.2-linux64/* /usr/


### PR DESCRIPTION
I hope this will help!
Since Bitcoin Classic was released, maybe we can add the DockerFile for this other client fork.

https://github.com/bitcoinclassic/bitcoinclassic/releases/tag/v0.11.2.cl1
